### PR TITLE
Fix eligibility setting checks

### DIFF
--- a/Source/InSituation.cs
+++ b/Source/InSituation.cs
@@ -107,7 +107,7 @@ namespace SimpleLogistics
         internal static double InSpeed(Vessel vessel)
         {
 
-            if (HighLogic.CurrentGame.Parameters.CustomParams<OptionsC>().maxDistance == 0f 
+            if (HighLogic.CurrentGame.Parameters.CustomParams<OptionsC>().maxGroundSpeed == 0f
                 || vessel.srfSpeed <= HighLogic.CurrentGame.Parameters.CustomParams<OptionsC>().maxGroundSpeed) return 0f;
             else return vessel.srfSpeed;
         }
@@ -160,7 +160,7 @@ namespace SimpleLogistics
                     if (!HighLogic.CurrentGame.Parameters.CustomParams<OptionsB>().yesEscaping) return Localizer.Format("#SLOG-msgSituation", Localizer.Format("#SLOG-Escaping"));
                     break;
                 case Vessel.Situations.DOCKED:
-                    if (!HighLogic.CurrentGame.Parameters.CustomParams<OptionsB>().yesLanded) return Localizer.Format("#SLOG-msgSituation", Localizer.Format("#SLOG-Docked"));
+                    if (!HighLogic.CurrentGame.Parameters.CustomParams<OptionsB>().yesDocked) return Localizer.Format("#SLOG-msgSituation", Localizer.Format("#SLOG-Docked"));
                     break;
             }
             return String.Empty;


### PR DESCRIPTION
## Summary
- Honor `maxGroundSpeed == 0` as the unlimited ground-speed setting in `InSpeed()`.
- Honor `yesDocked` for docked-vessel eligibility instead of reading the landed-vessel setting.

Closes #66.

## Why
Issue #66 points out two setting-read mixups. This patch is intentionally narrow and only changes those reads so the existing settings behave as labeled.

## Validation
- `git diff --check origin/2.0.99.0-prerelease...HEAD`
- Focused baseline-vs-patched eligibility harness:
  - baseline fails the `maxGroundSpeed=0` case when `maxDistance` is nonzero
  - baseline allows a docked vessel when `yesLanded=true` and `yesDocked=false`
  - patched passes both of those cases, plus the nonzero speed-limit and `yesDocked=true` docked-vessel cases
- Source compile with Mono C# against KSP 1.12.5.3190 managed assemblies, ToolbarController `1:0.1.9.14`, and ClickThroughBlocker `1:2.1.10.22`.
- Headless KSP 1.12.5.3190 load smoke with ModuleManager `4.2.3`, ToolbarController `1:0.1.9.14`, ClickThroughBlocker `1:2.1.10.22`, and the patched `SimpleLogistics.dll` reached MAINMENU. The smoke log showed:
  - `AssemblyLoader: KSPAssembly 'SimpleLogistics' V2.0.6`
  - `Scene Change : From LOADING to MAINMENU`
  - `OptionsA`, `OptionsB`, and `OptionsC` custom parameter classes loaded
  - no `[ERR]`, assembly loader exception, or exception lines

## Not tested
- Interactive vessel/gameplay scenario in a saved game.

## Pull request checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the code style of this project.
- [x] Have you checked to ensure there are no other open pull requests for the same update/change?
- [x] The commit message follows the guidelines.
- [x] All new and existing tests passed.
